### PR TITLE
Modified bbhw.erl to be less segmented.

### DIFF
--- a/code/elixir/README.md
+++ b/code/elixir/README.md
@@ -10,13 +10,23 @@ Elixir is written in Erlang and requires the [OTP] and Elixir runtime systems
 be installed. This Elixir script has been tested under Windows and [WSL2] 
 running [Ubuntu].
 
-In Windows, the Erlang OTP and Elixir runtime environments [must be installed][winstall] 
-before the Elixir script will execute.
+In Windows, the Erlang OTP and Elixir runtime environments [must be installed][winstall] before the Elixir script will execute.
 
 In Linux, `run` and `setenv` will install a local copy of the runtimes if they
 are not installed, globally.
 
 ## Usage
+
+### Files
+
+- `bbhw.ex` defines the `BBHW` module. It may be compiled with the Elixir shell 
+  `iex` and it's public functions `main()` and `main(arg)` called directly.
+
+- `bbhw.exs` is an Elixir script that imports `bbhw.ex` and passes any command 
+  line arguments to `main(arg)`.
+
+- `bbhw-orig.ex` is the original, much more verbose and segmented, version of
+  the `BBHW` module.   
 
 ### Parameters
 
@@ -33,7 +43,7 @@ Executes `bbhw.exs` in the [scripting engine][elixir]. Calls `setenv` to verify
 the Erlang OTP and Elixir runtimes are installed.
 
 
-### `setver` Command
+### `setenv` Command
 
 Verifies the Erlang OTP and Elixir runtimes are installed and sets `PATH` to
 include the runtime commands. On Linux, a local copy will be installed if not 

--- a/code/elixir/bbhw-orig.ex
+++ b/code/elixir/bbhw-orig.ex
@@ -1,0 +1,71 @@
+defmodule BBHW do
+
+  def main(),   do: run()
+  def main([]), do: run()
+  def main(arg) when is_atom(arg), do: isBadArg(arg)
+  def main(arg) when is_list(arg), do: main(hd(arg))
+
+  def main(arg) when is_integer(arg) do
+    case isItGood(arg) do
+      true  -> run(arg)
+      false -> isBadArg(arg)
+    end
+  end
+
+  def main(arg) do
+    case getCountdown arg do
+      :error -> run()
+      count  -> run(count)
+    end
+  end
+
+  defp getCountdown(s) do
+    case Integer.parse(s) do
+      {i, ""} -> case isItGood i do
+        true -> i
+        _   -> isNotGood(i)
+      end
+      _ -> isNotGood(s)
+    end
+  end
+
+  defp isBadArg(arg) do
+    isNotGood(arg)
+    run()
+  end
+
+  defp isItGood(i), do: i >= 0
+
+  defp isNotGood(a) when is_atom(a),   do: isNotGood(to_string(a))
+  defp isNotGood(s) when is_binary(s), do: isNotGood("\"#{s}\"", :print)
+  defp isNotGood(i), do: isNotGood(i, :print)
+  defp isNotGood(v, :print) do
+    IO.puts("Invalid countdown #{v}, try again...")
+    :error
+  end
+
+  defp readInput() do
+    case IO.gets("countdown: ") |> String.trim() do
+      ""   -> readInput()
+      line -> case getCountdown(line) do
+        :error -> readInput()
+        i      -> i
+      end
+    end
+  end
+
+  defp run(), do: run(readInput())   
+  defp run(count) do
+    IO.write("World, Hello...")
+    rundown(count)
+    IO.puts("Bye Bye.")
+  end
+    
+  defp rundown(0), do: :ok
+  defp rundown(count) do
+    IO.write("#{count}...")
+    Process.sleep(1000) 
+    rundown(count-1)
+  end
+end
+

--- a/code/elixir/bbhw.ex
+++ b/code/elixir/bbhw.ex
@@ -1,6 +1,6 @@
 defmodule BBHW do
 
-  def isBadArg(v), do: IO.puts("Invalid countdown \"#{v}\", try again...")
+  defp isBadArg(v), do: IO.puts("Invalid countdown \"#{v}\", try again...")
   
   def main() do
     case IO.gets("countdown: ") |> String.trim() do

--- a/code/elixir/bbhw.ex
+++ b/code/elixir/bbhw.ex
@@ -1,60 +1,36 @@
 defmodule BBHW do
 
-  def main(),   do: run()
-  def main([]), do: run()
-  def main(arg) when is_atom(arg), do: isBadArg(arg)
-  def main(arg) when is_list(arg), do: main(hd(arg))
-
-  def main(arg) when is_integer(arg) do
-    case isItGood(arg) do
-      true  -> run(arg)
-      false -> isBadArg(arg)
-    end
-  end
-
-  def main(arg) do
-    case getCountdown arg do
-      :error -> run()
-      count  -> run(count)
-    end
-  end
-
-  defp getCountdown(s) do
-    case Integer.parse(s) do
-      {i, ""} -> case isItGood i do
-        true -> i
-        _   -> isNotGood(i)
-      end
-      _ -> isNotGood(s)
-    end
-  end
-
-  defp isBadArg(arg) do
-    isNotGood(arg)
-    run()
-  end
-
-  defp isItGood(i), do: i >= 0
-
-  defp isNotGood(a) when is_atom(a),   do: isNotGood(to_string(a))
-  defp isNotGood(s) when is_binary(s), do: isNotGood("\"#{s}\"", :print)
-  defp isNotGood(i), do: isNotGood(i, :print)
-  defp isNotGood(v, :print) do
-    IO.puts("Invalid countdown #{v}, try again...")
-    :error
-  end
-
-  defp readInput() do
+  def isBadArg(v), do: IO.puts("Invalid countdown \"#{v}\", try again...")
+  
+  def main() do
     case IO.gets("countdown: ") |> String.trim() do
-      ""   -> readInput()
-      line -> case getCountdown(line) do
-        :error -> readInput()
-        i      -> i
-      end
+      ""   -> main()
+      line -> main(line)
     end
   end
 
-  defp run(), do: run(readInput())   
+  def main(a) when is_atom(a),  do: (isBadArg(a); main())
+  def main(f) when is_float(f), do: (isBadArg(f); main())
+  def main(l) when is_list(l),  do: main(hd(l ++ [""]))
+
+  def main(s) when is_binary(s) do
+    case String.length(s) > 0 do
+      true -> 
+        case Integer.parse(s) do
+          {i, ""} -> main(i)
+          _       -> isBadArg(s); main()
+        end
+      false -> main()
+    end
+  end
+  
+  def main(i) when is_integer(i) do
+    case i >= 0 do
+      true  -> run(i)
+      false -> isBadArg(i); main()
+    end
+  end
+
   defp run(count) do
     IO.write("World, Hello...")
     rundown(count)

--- a/code/erlang/README.md
+++ b/code/erlang/README.md
@@ -1,21 +1,33 @@
 # Erlang/OTP
 
-[Erlang] is a [Functional Programming] language developed by Ericsson specifically for development of 
-telephony applications. The [OTP] is a set of libraries, written in Erlang, comprising the Erlang
-interpreter, compiler, and runtime shell.
+[Erlang] is a [Functional Programming] language developed by Ericsson specifically 
+for development of telephony applications. The [OTP] is a set of libraries, 
+written in Erlang, comprising the Erlang interpreter, compiler, and runtime shell.
 
 This Erlang script has been tested under Windows and [WSL2] running [Ubuntu].
 
 ## Installing the OTP
 
-Under Linux, the `run` command will optionally install a local copy of the OTP, if a global one is not
-found, before running the Erlang script. It takes about 10 minutes to install.
+Under Linux, the `run` command will optionally install a local copy of the OTP, 
+if a global one is not found, before running the Erlang script. It takes about 
+10 minutes to install.
 
-There is no command to run the script under Windows and [Installing the OTP] globally is the best 
-option for Windows and Linux. 
+There is no command to run the script under Windows and [Installing the OTP] 
+globally is the best option for Windows and Linux. 
 
 
 ## Usage
+
+### Files
+
+- `bbhw.erl` defines the `bbhw` module. It may be compiled with the Erlang shell 
+  `erl` and it's public functions `main()` and `main(arg)` called directly.
+
+- `bbhw.exs` is an Elixir script that imports `bbhw.ex` and passes any command 
+  line arguments to `main(arg)`.
+
+- `bbhw-orig.erl` is the original, much more verbose and segmented, version of
+  the `bbhw` module.   
 
 ### Parameters
 

--- a/code/erlang/bbhw-orig.erl
+++ b/code/erlang/bbhw-orig.erl
@@ -1,0 +1,72 @@
+-module(bbhw).
+-export([main/0, main/1]).
+
+main()    -> main([]).             % `erl -noshell -s bbhw main [countdown] -s init stop`
+main([])  -> run();                % `escript bbhw.erl [countdown]`
+                                   % when countdown is not supplied.
+
+main(Arg) when is_integer(Arg) ->  % `bbhw:main(<nnn>)` from shell.
+  case isItGood(Arg) of
+    true  -> run(Arg);
+    false -> isBadArg(Arg)
+  end;
+  
+main(Arg) ->
+  Is_string = io_lib:printable_list(Arg),
+  Is_list   = is_list(Arg),    
+  Is_atom   = is_atom(Arg),        % `erl -noshell` args come in as atoms.
+  
+  if 
+    Is_string -> 
+      case getCountdown(Arg) of
+        error -> main();
+        C     -> run(C)
+      end;
+      
+    Is_list -> main(hd(Arg));      % true for `Is_string`.
+    Is_atom -> main(atom_to_list(Arg));
+    true    -> isBadArg(Arg)
+  end.
+  
+getCountdown(S) ->
+  case string:to_integer(S) of
+    {I, []} -> case isItGood(I) of 
+      true -> I; 
+      _    -> isNotGood(I) 
+    end;
+    _ -> isNotGood(S)
+  end.
+   
+isBadArg(Arg) ->
+  isNotGood(Arg),
+  run().
+
+isItGood(I) -> 
+  I >= 0.
+
+isNotGood(S) -> 
+  io:format("Invalid countdown ~p, try again...\n", [S]), 
+  error.
+    
+readInput() ->
+  case io:get_line("countdown: ") of
+    eof        -> readInput();
+    {error, _} -> readInput();
+    "\n"       -> readInput();
+    Line       -> case getCountdown(string:strip(Line, right, $\n)) of
+      error -> readInput();
+      I     -> I
+    end
+  end.
+
+run()  -> run(readInput()).    
+run(C) ->
+  io:format("World, Hello..."),
+  rundown(C),
+  io:format("Bye Bye.\n").
+  
+rundown(0) -> ok;
+rundown(C) ->
+  io:format("~B...", [C]),
+  timer:sleep(1000), 
+  rundown(C-1).

--- a/code/erlang/bbhw.erl
+++ b/code/erlang/bbhw.erl
@@ -1,68 +1,43 @@
 -module(bbhw).
 -export([main/0, main/1]).
 
-main()    -> main([]).             % `erl -noshell -s bbhw main [countdown] -s init stop`
-main([])  -> run();                % `escript bbhw.erl [countdown]`
-                                   % when countdown is not supplied.
+isBadArg(S) -> io:format("Invalid countdown ~p, try again...\n", [S]).
+isBadNum(N) -> isBadArg(lists:flatten(io_lib:format("~p", [N]))).
 
-main(Arg) when is_integer(Arg) ->  % `bbhw:main(<nnn>)` from shell.
-  case isItGood(Arg) of
-    true  -> run(Arg);
-    false -> isBadArg(Arg)
-  end;
-  
-main(Arg) ->
-  Is_string = io_lib:printable_list(Arg),
-  Is_list   = is_list(Arg),    
-  Is_atom   = is_atom(Arg),        % `erl -noshell` args come in as atoms.
-  
-  if 
-    Is_string -> 
-      case getCountdown(Arg) of
-        error -> main();
-        C     -> run(C)
-      end;
-      
-    Is_list -> main(hd(Arg));      % true for `Is_string`.
-    Is_atom -> main(atom_to_list(Arg));
-    true    -> isBadArg(Arg)
-  end.
-  
-getCountdown(S) ->
-  case string:to_integer(S) of
-    {I, []} -> case isItGood(I) of 
-      true -> I; 
-      _    -> isNotGood(I) 
-    end;
-    _ -> isNotGood(S)
-  end.
-   
-isBadArg(Arg) ->
-  isNotGood(Arg),
-  run().
-
-isItGood(I) -> 
-  I >= 0.
-
-isNotGood(S) -> 
-  io:format("Invalid countdown ~p, try again...\n", [S]), 
-  error.
-    
-readInput() ->
+main() ->
   case io:get_line("countdown: ") of
-    eof        -> readInput();
-    {error, _} -> readInput();
-    "\n"       -> readInput();
-    Line       -> case getCountdown(string:strip(Line, right, $\n)) of
-      error -> readInput();
-      I     -> I
-    end
+    eof        -> main();
+    {error, _} -> main();
+    "\n"       -> main();
+    Line       -> main(string:strip(Line, right, $\n))
   end.
 
-run()  -> run(readInput()).    
-run(C) ->
+main(A) when is_atom(A)  -> main(atom_to_list(A));
+main(F) when is_float(F) -> isBadNum(F), main();
+
+main(L) when is_list(L) ->
+  case io_lib:printable_list(L) of
+    true  -> 
+      case string:len(L) > 0 of
+        true  -> 
+          case string:to_integer(L) of
+            {I, []} -> main(I);
+            _       -> isBadArg(L), main()
+          end;
+        false -> main()
+      end;
+    false -> main(hd(L))
+  end;
+
+main(I) when is_integer(I) ->  
+  case I >= 0 of
+    true  -> run(I);
+    false -> isBadNum(I), main()
+  end.
+
+run(Count) ->
   io:format("World, Hello..."),
-  rundown(C),
+  rundown(Count),
   io:format("Bye Bye.\n").
   
 rundown(0) -> ok;


### PR DESCRIPTION
This version is much less segmented than the original but it is still not a single execution stream which I think is what you were asking for, @c4augustus. This new version supports all the ways to run this using `escript`, `erl`, or `erl -noshell`. To allow it only to run through `escript` means these two lines could be removed:
```
main(A) when is_atom(A)  -> main(atom_to_list(A));
main(F) when is_float(F) -> isBadNum(F), main();
```

`main()` without parameters simply reads the `countdown:` input from the console and calls `main(_)` with the result. The body of `main()` could be moved to line 27, thus keeping all the processing inside of `main(_)`. We would still need `main() -> main("")`, however, and I like it this way better, anyway, because it clearly says "main with no parameters takes countdown input."

The lack of mutability and traditional looping statements makes it very challenging to do what you asked. While it may be possible with lambdas, I hardly think it's worth it and it seems counter to tacit Erlang development.

Anyway, take a look and let me know what you think. 